### PR TITLE
[OTEL-228] Add CI for opentelemetry-demo images 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,20 +18,20 @@ stages:
     - TAG="v$CI_COMMIT_SHORT_SHA-$IMAGE_TAG_SUFFIX"
     - docker build --file $DOCKERFILE --tag registry.ddbuild.io/ci/opentelemetry-demo:$TAG --label target=staging $CONTEXT
     - docker push registry.ddbuild.io/ci/opentelemetry-demo:$TAG
-  variables:
-    CONTEXT: .
 
 build-ci-image-adservice:
   <<: *build-ci-image
   variables:
     DOCKERFILE: src/adservice/Dockerfile
     IMAGE_TAG_SUFFIX: adservice
+    CONTEXT: .
 
 build-ci-image-cartservice:
   <<: *build-ci-image
   variables:
     DOCKERFILE: src/cartservice/src/Dockerfile
     IMAGE_TAG_SUFFIX: cartservice
+    CONTEXT: .
 
 build-ci-image-checkoutservice:
   <<: *build-ci-image
@@ -45,6 +45,7 @@ build-ci-image-currencyservice:
   variables:
     DOCKERFILE: src/currencyservice/Dockerfile
     IMAGE_TAG_SUFFIX: currencyservice
+    CONTEXT: .
 
 
 build-ci-image-emailservice:
@@ -59,51 +60,60 @@ build-ci-image-featureflagservice:
   variables:
     DOCKERFILE: src/featureflagservice/Dockerfile
     IMAGE_TAG_SUFFIX: featureflagservice
+    CONTEXT: .
 
 build-ci-image-frontend:
   <<: *build-ci-image
   variables:
     DOCKERFILE: src/frontend/Dockerfile
     IMAGE_TAG_SUFFIX: frontend
+    CONTEXT: .
 
 build-ci-image-frontendproxy:
   <<: *build-ci-image
   variables:
     DOCKERFILE: src/frontendproxy/Dockerfile
     IMAGE_TAG_SUFFIX: frontendproxy
+    CONTEXT: .
 
 build-ci-image-loadgenerator:
   <<: *build-ci-image
   variables:
     DOCKERFILE: src/loadgenerator/Dockerfile
     IMAGE_TAG_SUFFIX: loadgenerator
+    CONTEXT: .
 
 build-ci-image-paymentservice:
   <<: *build-ci-image
   variables:
     DOCKERFILE: src/paymentservice/Dockerfile
     IMAGE_TAG_SUFFIX: paymentservice
+    CONTEXT: .
 
 build-ci-image-productcatalogservice:
   <<: *build-ci-image
   variables:
     DOCKERFILE: src/productcatalogservice/Dockerfile
     IMAGE_TAG_SUFFIX: productcatalogservice
+    CONTEXT: .
 
 build-ci-image-quoteservice:
   <<: *build-ci-image
   variables:
     DOCKERFILE: src/quoteservice/Dockerfile
     IMAGE_TAG_SUFFIX: quoteservice
+    CONTEXT: .
 
 build-ci-image-recommendationservice:
   <<: *build-ci-image
   variables:
     DOCKERFILE: src/recommendationservice/Dockerfile
     IMAGE_TAG_SUFFIX: recommendationservice
+    CONTEXT: .
 
 build-ci-image-shippingservice:
   <<: *build-ci-image
   variables:
     DOCKERFILE: src/shippingservice/Dockerfile
     IMAGE_TAG_SUFFIX: shippingservice
+    CONTEXT: .

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,8 +16,10 @@ stages:
   image: $CI_IMAGE
   script:
     - TAG="v$CI_COMMIT_SHORT_SHA-$IMAGE_TAG_SUFFIX"
-    - docker build --file $DOCKERFILE --tag registry.ddbuild.io/ci/opentelemetry-demo:$TAG --label target=staging .
+    - docker build --file $DOCKERFILE --tag registry.ddbuild.io/ci/opentelemetry-demo:$TAG --label target=staging $CONTEXT
     - docker push registry.ddbuild.io/ci/opentelemetry-demo:$TAG
+  variables:
+    CONTEXT: .
 
 build-ci-image-adservice:
   <<: *build-ci-image
@@ -36,6 +38,7 @@ build-ci-image-checkoutservice:
   variables:
     DOCKERFILE: src/checkoutservice/Dockerfile
     IMAGE_TAG_SUFFIX: checkoutservice
+    CONTEXT: .
 
 build-ci-image-currencyservice:
   <<: *build-ci-image
@@ -49,6 +52,7 @@ build-ci-image-emailservice:
   variables:
     DOCKERFILE: src/emailservice/Dockerfile
     IMAGE_TAG_SUFFIX: emailservice
+    CONTEXT: src/emailservice
 
 build-ci-image-featureflagservice:
   <<: *build-ci-image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,105 @@
+variables:
+  CI_IMAGE: registry.ddbuild.io/images/docker:20.10.13
+  RESTORE_CACHE_ATTEMPTS: 2
+  BUILD_STABLE_REGISTRY: '486234852809.dkr.ecr.us-east-1.amazonaws.com'
+
+stages:
+  - build
+
+# =======================================================================
+# Build and deploy the images used for CI
+# =======================================================================
+
+.build-ci-image: &build-ci-image
+  stage: build
+  tags: ["runner:docker"]
+  image: $CI_IMAGE
+  script:
+    - TAG="v$CI_COMMIT_SHORT_SHA-$IMAGE_TAG_SUFFIX"
+    - docker build --file $DOCKERFILE --tag registry.ddbuild.io/ci/opentelemetry-demo:$TAG --label target=staging .
+    - docker push registry.ddbuild.io/ci/opentelemetry-demo:$TAG
+
+build-ci-image-adservice:
+  <<: *build-ci-image
+  variables:
+    DOCKERFILE: src/adservice/Dockerfile
+    IMAGE_TAG_SUFFIX: adservice
+
+build-ci-image-cartservice:
+  <<: *build-ci-image
+  variables:
+    DOCKERFILE: src/cartservice/src/Dockerfile
+    IMAGE_TAG_SUFFIX: cartservice
+
+build-ci-image-checkoutservice:
+  <<: *build-ci-image
+  variables:
+    DOCKERFILE: src/checkoutservice/Dockerfile
+    IMAGE_TAG_SUFFIX: checkoutservice
+
+build-ci-image-currencyservice:
+  <<: *build-ci-image
+  variables:
+    DOCKERFILE: src/currencyservice/Dockerfile
+    IMAGE_TAG_SUFFIX: currencyservice
+
+
+build-ci-image-emailservice:
+  <<: *build-ci-image
+  variables:
+    DOCKERFILE: src/emailservice/Dockerfile
+    IMAGE_TAG_SUFFIX: emailservice
+
+build-ci-image-featureflagservice:
+  <<: *build-ci-image
+  variables:
+    DOCKERFILE: src/featureflagservice/Dockerfile
+    IMAGE_TAG_SUFFIX: featureflagservice
+
+build-ci-image-frontend:
+  <<: *build-ci-image
+  variables:
+    DOCKERFILE: src/frontend/Dockerfile
+    IMAGE_TAG_SUFFIX: frontend
+
+build-ci-image-frontendproxy:
+  <<: *build-ci-image
+  variables:
+    DOCKERFILE: src/frontendproxy/Dockerfile
+    IMAGE_TAG_SUFFIX: frontendproxy
+
+build-ci-image-loadgenerator:
+  <<: *build-ci-image
+  variables:
+    DOCKERFILE: src/loadgenerator/Dockerfile
+    IMAGE_TAG_SUFFIX: loadgenerator
+
+build-ci-image-paymentservice:
+  <<: *build-ci-image
+  variables:
+    DOCKERFILE: src/paymentservice/Dockerfile
+    IMAGE_TAG_SUFFIX: paymentservice
+
+build-ci-image-productcatalogservice:
+  <<: *build-ci-image
+  variables:
+    DOCKERFILE: src/productcatalogservice/Dockerfile
+    IMAGE_TAG_SUFFIX: productcatalogservice
+
+build-ci-image-quoteservice:
+  <<: *build-ci-image
+  variables:
+    DOCKERFILE: src/quoteservice/Dockerfile
+    IMAGE_TAG_SUFFIX: quoteservice
+
+build-ci-image-recommendationservice:
+  <<: *build-ci-image
+  variables:
+    DOCKERFILE: src/recommendationservice/Dockerfile
+    IMAGE_TAG_SUFFIX: recommendationservice
+
+build-ci-image-shippingservice:
+  <<: *build-ci-image
+  variables:
+    DOCKERFILE: src/shippingservice/Dockerfile
+    IMAGE_TAG_SUFFIX: shippingservice

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@ build-ci-image-currencyservice:
   variables:
     DOCKERFILE: src/currencyservice/Dockerfile
     IMAGE_TAG_SUFFIX: currencyservice
-    CONTEXT: .
+    CONTEXT: src/currencyservice
 
 
 build-ci-image-emailservice:

--- a/src/adservice/Dockerfile
+++ b/src/adservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM eclipse-temurin:17-jdk AS builder
+FROM registry.ddbuild.io/images/java:corretto-17 AS builder
 
 WORKDIR /usr/src/app/
 

--- a/src/checkoutservice/Dockerfile
+++ b/src/checkoutservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19.2-alpine AS builder
+FROM registry.ddbuild.io/images/mirror/golang:1.19-alpine AS builder
 RUN apk add build-base protobuf-dev protoc
 WORKDIR /usr/src/app/
 

--- a/src/checkoutservice/Dockerfile
+++ b/src/checkoutservice/Dockerfile
@@ -29,7 +29,7 @@ RUN go build -o /go/bin/checkoutservice/ ./
 
 # -----------------------------------------------------------------------------
 
-FROM alpine
+FROM registry.ddbuild.io/images/mirror/alpine:latest AS release
 
 WORKDIR /usr/src/app/
 

--- a/src/currencyservice/Dockerfile
+++ b/src/currencyservice/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM registry.ddbuild.io/images/base:focal
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get -y update

--- a/src/currencyservice/Dockerfile
+++ b/src/currencyservice/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.ddbuild.io/images/base:focal
 ENV DEBIAN_FRONTEND noninteractive
-
+USER root
 RUN apt-get -y update
 RUN apt-get -y upgrade && apt-get -y dist-upgrade
 RUN apt-get install -qq -y --ignore-missing \
@@ -55,5 +55,5 @@ COPY . /currencyservice
 RUN cd /currencyservice \
     && mkdir -p build && cd build \
     && cmake .. && make -j install
-
+USER 1001
 ENTRYPOINT /usr/local/bin/currencyservice ${CURRENCY_SERVICE_PORT}

--- a/src/emailservice/Dockerfile
+++ b/src/emailservice/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.2-slim
+FROM registry.ddbuild.io/images/mirror/ruby:3.1.2-slim
 
 RUN apt-get update -y && apt-get install -y build-essential
 

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ddbuild.io/images/mirror/node:18-bullseye AS deps
+FROM registry.ddbuild.io/images/mirror/node:18-alpine AS deps
 RUN apk add --no-cache libc6-compat
 
 WORKDIR /app

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS deps
+FROM registry.ddbuild.io/images/mirror/node:18-bullseye AS deps
 RUN apk add --no-cache libc6-compat
 
 WORKDIR /app

--- a/src/loadgenerator/Dockerfile
+++ b/src/loadgenerator/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.10 AS base
+FROM registry.ddbuild.io/images/mirror/python:3.9.13 AS base
 
 WORKDIR /usr/src/app/
 

--- a/src/paymentservice/Dockerfile
+++ b/src/paymentservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.ddbuild.io/images/mirror/node:18-bullseye AS build
+FROM registry.ddbuild.io/images/mirror/node:18-alpine AS build
 
 WORKDIR /usr/src/app/
 

--- a/src/paymentservice/Dockerfile
+++ b/src/paymentservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:16-alpine AS build
+FROM registry.ddbuild.io/images/mirror/node:18-bullseye AS build
 
 WORKDIR /usr/src/app/
 

--- a/src/productcatalogservice/Dockerfile
+++ b/src/productcatalogservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17.7-alpine AS builder
+FROM registry.ddbuild.io/images/mirror/golang:1.19-alpine AS builder
 
 WORKDIR /usr/src/app/
 

--- a/src/productcatalogservice/Dockerfile
+++ b/src/productcatalogservice/Dockerfile
@@ -23,8 +23,8 @@ COPY ./src/productcatalogservice/ ./
 COPY ./pb/ ./proto/
 
 RUN go mod download
-RUN go get google.golang.org/protobuf/cmd/protoc-gen-go
-RUN go get google.golang.org/grpc/cmd/protoc-gen-go-grpc
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
+RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
 
 # Build executable
 RUN protoc -I ./proto/ ./proto/demo.proto --go_out=./ --go-grpc_out=./
@@ -32,7 +32,7 @@ RUN go build -o /go/bin/productcatalogservice/ ./
 
 # -----------------------------------------------------------------------------
 
-FROM alpine AS release
+FROM registry.ddbuild.io/images/mirror/alpine:latest AS release
 
 WORKDIR /usr/src/app/
 

--- a/src/quoteservice/Dockerfile
+++ b/src/quoteservice/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer:2.4 AS build
+FROM registry.ddbuild.io/images/mirror/composer:2.4 AS build
 
 WORKDIR /tmp/
 COPY ./src/quoteservice/composer.json .

--- a/src/recommendationservice/Dockerfile
+++ b/src/recommendationservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.10
+FROM registry.ddbuild.io/images/mirror/python:3.9.13 AS base
 
 WORKDIR /usr/src/app/
 

--- a/src/shippingservice/Dockerfile
+++ b/src/shippingservice/Dockerfile
@@ -1,5 +1,5 @@
 # build context will only work from ../../docker-compose.yml
-FROM rust:1.61-alpine as builder
+FROM registry.ddbuild.io/images/mirror/rust:1.61-alpine as builder
 RUN apk update
 RUN apk add --no-cache ca-certificates git protobuf-dev protoc cmake clang clang-dev make gcc g++ libc-dev linux-headers
 WORKDIR /app/


### PR DESCRIPTION
Add gitlabci for building images in Datadog Repo . [PR](https://github.com/DataDog/images/pull/3300) setups mirror for few images necessary . 