### PR TITLE
Add spans with peer service attributes in checkoutservice

### DIFF
--- a/src/checkoutservice/main.go
+++ b/src/checkoutservice/main.go
@@ -250,6 +250,9 @@ func (cs *checkoutService) PlaceOrder(ctx context.Context, req *pb.PlaceOrderReq
 	shippingTrackingAttribute := attribute.String("app.shipping.tracking.id", shippingTrackingID)
 	span.AddEvent("shipped", trace.WithAttributes(shippingTrackingAttribute))
 
+	_, childSpan1 := tracer.Start(ctx, "callPeerService", trace.WithSpanKind(trace.SpanKindClient), trace.WithAttributes(attribute.String("peer.service", "demo-peer-service")))
+	childSpan1.End()
+
 	_ = cs.emptyUserCart(ctx, req.UserId)
 
 	orderResult := &pb.OrderResult{
@@ -315,6 +318,9 @@ func (cs *checkoutService) prepareOrderItemsAndShippingQuoteFromCart(ctx context
 	out.shippingCostLocalized = shippingPrice
 	out.cartItems = cartItems
 	out.orderItems = orderItems
+
+	_, childSpan2 := tracer.Start(ctx, "updateCache", trace.WithSpanKind(trace.SpanKindClient), trace.WithAttributes(attribute.String("db.system", "redis")))
+	childSpan2.End()
 
 	var totalCart int32
 	for _, ci := range cartItems {


### PR DESCRIPTION
# Changes

Add spans with peer service attributes in checkoutservice
https://datadoghq.atlassian.net/browse/OTEL-589

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
