### PR TITLE
Add deploy of demo to staging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,9 +5,11 @@ variables:
   RESTORE_CACHE_ATTEMPTS: 2
   BUILD_DD_REGISTRY: registry.ddbuild.io/ci/opentelemetry-demo
   BUILD_DEMO_REGISTRY: 172597598159.dkr.ecr.us-east-1.amazonaws.com/otel-demo
+  BUILD_SANDBOX_REGISTRY: 601427279990.dkr.ecr.us-east-1.amazonaws.com/otel-demo
 stages:
   - build
   - prod-deploy
+  - staging-deploy
 # =======================================================================
 # Build and deploy the images used for CI
 # =======================================================================
@@ -17,9 +19,13 @@ stages:
   image: $CI_IMAGE
   script:
     - TAG="v$CI_COMMIT_SHORT_SHA-$IMAGE_TAG_SUFFIX"
-    - docker build --file $DOCKERFILE --tag $BUILD_DD_REGISTRY:$TAG --tag $BUILD_DEMO_REGISTRY:$TAG --label target=staging $CONTEXT
-    - docker push $BUILD_DD_REGISTRY:$TAG
-    - docker push $BUILD_DEMO_REGISTRY:$TAG
+    - docker build --file $DOCKERFILE --tag $BUILD_SANDBOX_REGISTRY:$TAG --tag $BUILD_DEMO_REGISTRY:$TAG --label target=staging $CONTEXT
+    - if [[ $CI_COMMIT_REF_NAME =~ -staging$ ]]; then
+        docker push $BUILD_SANDBOX_REGISTRY:$TAG;
+      fi
+    - if [[ $CI_COMMIT_REF_NAME == "prod" ]]; then
+        docker push $BUILD_DEMO_REGISTRY:$TAG;
+      fi
 build-ci-image-accountingservice:
   !!merge <<: *build-ci-image
   variables:
@@ -116,9 +122,10 @@ build-ci-image-shippingservice:
   image: $CI_IMAGE
   script:
     - TAG="v$CI_COMMIT_SHORT_SHA-$IMAGE_TAG_SUFFIX"
-    - docker buildx build --file $DOCKERFILE --tag $BUILD_DD_REGISTRY:$TAG --tag $BUILD_DEMO_REGISTRY:$TAG --label target=staging $CONTEXT
+    - docker buildx build --file $DOCKERFILE --tag $BUILD_DD_REGISTRY:$TAG --tag $BUILD_DEMO_REGISTRY:$TAG --tag $BUILD_SANDBOX_REGISTRY:$TAG --label target=staging $CONTEXT
     - docker push $BUILD_DD_REGISTRY:$TAG
     - docker push $BUILD_DEMO_REGISTRY:$TAG
+    - docker push $BUILD_SANDBOX_REGISTRY:$TAG
   variables:
     DOCKERFILE: src/shippingservice/Dockerfile
     IMAGE_TAG_SUFFIX: shippingservice
@@ -141,7 +148,6 @@ build-ci-image-orderproducer:
   image: $CI_IMAGE
   rules:
     - if: '$CI_COMMIT_REF_NAME == "prod"'
-    - if: '$CI_COMMIT_REF_NAME =~ /-staging$/'
   script:
     # # For debugging
     #- aws sts get-caller-identity
@@ -149,11 +155,8 @@ build-ci-image-orderproducer:
       TEMP_AWS_ACCESS_KEY_ID=$(aws ssm get-parameter --region us-east-1 --name ci.opentelemetry-demo.eks_access_key --with-decryption --query Parameter.Value --out text)
     - >-
       TEMP_AWS_SECRET_ACCESS_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.opentelemetry-demo.eks_secret_access_key --with-decryption --query Parameter.Value --out text)
-    - >-
-      TEMP_DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.opentelemetry-demo.dd-demo-api --with-decryption --query Parameter.Value --out text)
     - export AWS_ACCESS_KEY_ID=$TEMP_AWS_ACCESS_KEY_ID
     - export AWS_SECRET_ACCESS_KEY=$TEMP_AWS_SECRET_ACCESS_KEY
-    - export DD_API_KEY=$TEMP_DD_API_KEY
     # # For debugging
     # - aws sts get-caller-identity
     - bash $SCRIPT $CLUSTER_NAME $CLUSTER_ARN $REGION $NAMESPACE
@@ -181,3 +184,52 @@ prod-deploy-otel-ingest-agent-eks:
     CLUSTER_ARN: arn:aws:eks:us-east-2:172597598159:cluster/otel-ingest-demo
     REGION: us-east-2
     NAMESPACE: otel-ingest
+    VALUES: ./ci/datadog-agent-values-prod.yaml
+.staging-deploy: &staging-deploy
+  stage: staging-deploy
+  tags: ["runner:docker", "size:large"]
+  image: $CI_IMAGE
+  rules:
+    - if: '$CI_COMMIT_REF_NAME =~ /-staging$/'
+  script:
+    # # For debugging
+    #- aws sts get-caller-identity
+    - >-
+      TEMP_AWS_ACCESS_KEY_ID=$(aws ssm get-parameter --region us-east-1 --name ci.opentelemetry-demo.sand-eks-deploy-api-key --with-decryption --query Parameter.Value --out text)
+    - >-
+      TEMP_AWS_SECRET_ACCESS_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.opentelemetry-demo.sand-eks-deploy-access-key --with-decryption --query Parameter.Value --out text)
+    - export AWS_ACCESS_KEY_ID=$TEMP_AWS_ACCESS_KEY_ID
+    - export AWS_SECRET_ACCESS_KEY=$TEMP_AWS_SECRET_ACCESS_KEY
+    # # For debugging
+    # - aws sts get-caller-identity
+    - bash $SCRIPT
+
+staging-deploy-otel-demo-eks:
+  !!merge <<: *staging-deploy
+  variables:
+    NAMESPACE: otel-staging
+    VALUES: ./ci/values-staging.yaml
+    NODE_GROUP: ng-3
+    SCRIPT: ./ci/scripts/ci-deploy-demo-staging.sh
+    CLUSTER_NAME: dd-otel
+    CLUSTER_ARN: "arn:aws:eks:us-east-1:601427279990:cluster/dd-otel"
+    REGION: us-east-1
+staging-deploy-otel-ingest-demo-eks:
+  !!merge <<: *staging-deploy
+  variables:
+    NAMESPACE: otel-ingest-staging
+    VALUES: ./ci/values-ingest-staging.yaml
+    NODE_GROUP: ng-4
+    SCRIPT: ./ci/scripts/ci-deploy-demo-staging.sh
+    CLUSTER_NAME: dd-otel
+    CLUSTER_ARN: "arn:aws:eks:us-east-1:601427279990:cluster/dd-otel"
+    REGION: us-east-1
+staging-deploy-otel-ingest-agent-eks:
+  !!merge <<: *staging-deploy
+  variables:
+    NAMESPACE: otel-ingest-staging
+    SCRIPT: ./ci/scripts/ci-deploy-agent.sh
+    CLUSTER_NAME: dd-otel
+    CLUSTER_ARN: "arn:aws:eks:us-east-1:601427279990:cluster/dd-otel"
+    REGION: us-east-1
+    VALUES: ./ci/datadog-agent-values-staging.yaml

--- a/ci/datadog-agent-values-prod.yaml
+++ b/ci/datadog-agent-values-prod.yaml
@@ -1,0 +1,3 @@
+datadog:
+  tags:
+    - "env:otel-ingest"

--- a/ci/datadog-agent-values-staging.yaml
+++ b/ci/datadog-agent-values-staging.yaml
@@ -1,0 +1,6 @@
+agents:
+  nodeSelector:
+    alpha.eksctl.io/nodegroup-name: ng-4
+datadog:
+  tags:
+    - "env:otel-ingest-staging"

--- a/ci/datadog-agent-values.yaml
+++ b/ci/datadog-agent-values.yaml
@@ -2,10 +2,9 @@ agents:
   image:
     tagSuffix: jmx
 datadog:
+  apiKey: $DD_API_KEY
   logs:
     enabled: true
-  tags:
-    - "env:otel-ingest"
   otlp:
     receiver:
       protocols:
@@ -13,3 +12,10 @@ datadog:
           enabled: true
         http:
           enabled: true
+  env:
+    - name: DD_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: datadog-secrets
+          key: api-key
+          optional: false

--- a/ci/scripts/ci-deploy-agent.sh
+++ b/ci/scripts/ci-deploy-agent.sh
@@ -8,10 +8,12 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-clusterName=$1
-clusterArn=$2
-region=$3
-namespace=$4
+clusterName=$CLUSTER_NAME
+clusterArn=$CLUSTER_ARN
+region=$REGION
+namespace=$NAMESPACE
+values=$VALUES
+
 install_agent() {
   # Set the namespace and release name
   release_name="datadog-agent"
@@ -21,8 +23,8 @@ install_agent() {
 
   # --install will run `helm install` if not already present.
   helm upgrade "${release_name}" -n "${namespace}" datadog/datadog --install \
-    -f ./ci/datadog-agent-values.yaml --set datadog.apiKey=$DD_API_KEY
-
+    -f ./ci/datadog-agent-values.yaml \
+    -f "${values}"
 }
 
 ###########################################################################################################

--- a/ci/scripts/ci-deploy-demo-staging.sh
+++ b/ci/scripts/ci-deploy-demo-staging.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# This script is used to deploy collector on demo account cluster
+
+set -euo pipefail
+IFS=$'\n\t'
+set -x
+
+clusterName=$CLUSTER_NAME
+clusterArn=$CLUSTER_ARN
+region=$REGION
+namespace=$NAMESPACE
+nodeGroup=$NODE_GROUP
+values=$VALUES
+
+install_demo() {
+  # Set the namespace and release name
+  release_name="opentelemetry-demo"
+
+  # Deploy zookeeper which is not a default component.
+  sed -i "s/PLACEHOLDER_NODE_GROUP/v$nodeGroup/g" ./src/zookeeperservice/deployment-staging.yaml
+  kubectl apply -f ./src/zookeeperservice/deployment-staging.yaml -n "${namespace}"
+
+  # if repo already exists, helm 3+ will skip
+  helm --debug repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+
+  # --install will run `helm install` if not already present.
+  helm --debug upgrade "${release_name}" -n "${namespace}" open-telemetry/opentelemetry-demo --install \
+    -f ./ci/values.yaml \
+    -f $values \
+    --set-string default.image.tag="v$CI_COMMIT_SHORT_SHA" \
+    --set-string default.image.repository="601427279990.dkr.ecr.us-east-1.amazonaws.com/otel-demo"
+  
+  # Deploy java order producer which is not a default component.
+  sed -i "s/PLACEHOLDER_COMMIT_SHA/v$CI_COMMIT_SHORT_SHA/g" ./src/orderproducerservice/deployment-staging.yaml
+  sed -i "s/PLACEHOLDER_NODE_GROUP/v$nodeGroup/g" ./src/orderproducerservice/deployment-staging.yaml
+  kubectl apply -f ./src/orderproducerservice/deployment-staging.yaml -n "${namespace}"
+}
+
+###########################################################################################################
+
+aws eks --region "${region}" update-kubeconfig --name "${clusterName}"
+kubectl config use-context "${clusterArn}"
+
+install_demo

--- a/ci/values-ingest-staging.yaml
+++ b/ci/values-ingest-staging.yaml
@@ -1,0 +1,4 @@
+default:
+  schedulingRules:
+    nodeSelector:
+      alpha.eksctl.io/nodegroup-name: ng-4

--- a/ci/values-staging.yaml
+++ b/ci/values-staging.yaml
@@ -1,0 +1,4 @@
+default:
+  schedulingRules:
+    nodeSelector:
+      alpha.eksctl.io/nodegroup-name: ng-3

--- a/src/orderproducerservice/deployment-staging.yaml
+++ b/src/orderproducerservice/deployment-staging.yaml
@@ -1,0 +1,142 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opentelemetry-demo-orderproducer
+  labels:
+    app.kubernetes.io/component: orderproducer
+    app.kubernetes.io/instance: opentelemetry-demo
+    app.kubernetes.io/name: opentelemetry-demo-orderproducer
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/version: "1.4.0"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-demo-orderproducer
+  template:
+    metadata:
+      annotations:
+        ad.datadoghq.com/orderproducer.logs: '[{"source":"kafka","service":"orderproducer"}]'
+        ad.datadoghq.com/orderproducer.checks: |
+          {
+            "kafka": {
+              "init_config": {
+                "is_jmx": true,
+                "collect_default_metrics": true
+              },
+              "instances": [
+                {
+                  "host": "opentelemetry-demo-orderproducer",
+                  "port": "1097",
+                  "tags": [
+                    "kafka_source:agent"
+                  ]
+                }
+              ]
+            }
+          }
+      labels:
+        app.kubernetes.io/component: orderproducer
+        app.kubernetes.io/instance: opentelemetry-demo
+        app.kubernetes.io/name: opentelemetry-demo-orderproducer
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: alpha.eksctl.io/nodegroup-name
+                    operator: In
+                    values:
+                      - ng-4
+      initContainers:
+        - command:
+          - sh
+          - -c
+          - until nc -z -v -w30 opentelemetry-demo-kafka 9092; do echo waiting
+            for kafka; sleep 2; done;
+          image: busybox:latest
+          name: wait-for-kafka
+      containers:
+        - name: orderproducer
+          image: 601427279990.dkr.ecr.us-east-1.amazonaws.com/otel-demo:PLACEHOLDER_COMMIT_SHA-orderproducer
+          imagePullPolicy: IfNotPresent
+          ports:
+          - containerPort: 1097
+            name: producerjmx
+            protocol: TCP
+          env:
+          - name: KAFKA_SERVICE_ADDR
+            value: "opentelemetry-demo-kafka:9092"
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: OTEL_SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: "metadata.labels['app.kubernetes.io/component']"
+          - name: OTEL_K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: OTEL_K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: spec.nodeName
+          - name: OTEL_K8S_POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: OTEL_K8S_POD_UID
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.uid
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: OTEL_COLLECTOR_NAME
+            value: $(HOST_IP)
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: >-
+              service.name=$(OTEL_SERVICE_NAME),
+              service.instance.id=$(OTEL_K8S_POD_UID),
+              service.namespace=opentelemetry-demo,
+              k8s.namespace.name=$(OTEL_K8S_NAMESPACE),
+              k8s.node.name=$(OTEL_K8S_NODE_NAME),
+              k8s.pod.name=$(OTEL_K8S_POD_NAME),
+              deployment.environment=$(OTEL_K8S_NAMESPACE),
+              k8s.pod.ip=$(POD_IP)
+          resources:
+            limits:
+              memory: 1Gi
+          securityContext:
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000                                
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: opentelemetry-demo-orderproducer
+spec:
+  selector:
+    app.kubernetes.io/name: opentelemetry-demo-orderproducer
+  ports:
+  - name: orderproducer
+    port: 1097
+    protocol: TCP
+    targetPort: 1097

--- a/src/zookeeperservice/deployment-staging.yaml
+++ b/src/zookeeperservice/deployment-staging.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opentelemetry-demo-zookeeper
+  labels:
+    app.kubernetes.io/component: zookeeper
+    app.kubernetes.io/instance: opentelemetry-demo
+    app.kubernetes.io/name: opentelemetry-demo-zookeeper
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/version: "1.4.0"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-demo-zookeeper
+  template:
+    metadata:
+      annotations:
+        ad.datadoghq.com/zookeeper.logs: '[{"source":"zookeeper","service":"zookeeper"}]'
+        ad.datadoghq.com/zookeeper.checks: |
+          {
+            "zk": {
+              "instances": [
+                {
+                  "host": "opentelemetry-demo-zookeeper",
+                  "port": "2181",
+                  "tags": [
+                    "zookeeper_source:agent"
+                  ]
+                }
+              ]
+            }
+          }
+      labels:
+        app.kubernetes.io/component: zookeeper
+        app.kubernetes.io/instance: opentelemetry-demo
+        app.kubernetes.io/name: opentelemetry-demo-zookeeper
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: alpha.eksctl.io/nodegroup-name
+                    operator: In
+                    values:
+                      - ng-4
+      containers:
+        - name: zookeeper
+          image: confluentinc/cp-zookeeper:7.2.2
+          imagePullPolicy: IfNotPresent
+          ports:
+          - containerPort: 2181
+            name: zookeeper
+            protocol: TCP
+          env:
+          - name: ZOOKEEPER_TICK_TIME
+            value: "2000"
+          - name: ZOOKEEPER_CLIENT_PORT
+            value: "2181"
+          - name: KAFKA_OPTS
+            value: "-Dzookeeper.4lw.commands.whitelist=*" 
+          resources:
+            limits:
+              memory: 1Gi
+          securityContext:
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: opentelemetry-demo-zookeeper
+spec:
+  selector:
+    app.kubernetes.io/name: opentelemetry-demo-zookeeper
+  ports:
+  - name: zookeeper
+    port: 2181
+    protocol: TCP
+    targetPort: 2181


### PR DESCRIPTION
This PR adds staging deployment for commit `*-staging`.
- **opentelemetry-demo** is deployed on `ng-3` of sandbox cluster, where the collector is deployed: https://github.com/DataDog/opentelemetry-collector-contrib/pull/4205. (`env:otel-staging`) | [Link to traces](https://app.datadoghq.com/apm/traces?query=%40_top_level%3A1%20env%3Aotel-staging%20&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&historicalData=false&messageDisplay=inline&query_translation_version=v0&sort=desc&spanType=service-entry&start=1692174186045&end=1692175086045&paused=false)
- **opentelemetry-demo** and **datadog-agent** are deployed on `ng-4` of sandbox cluster (`env:otel-ingest-staging`) | [Link to traces](https://app.datadoghq.com/apm/traces?query=%40_top_level%3A1%20env%3Aotel-ingest-staging&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&historicalData=false&messageDisplay=inline&query_translation_version=v0&sort=desc&spanType=service-entry&start=1692174247043&end=1692175147043&paused=false)


![staging](https://github.com/DataDog/opentelemetry-demo/assets/63265430/272f3cbb-26aa-4599-9c97-f60ec26a97de)