### PR TITLE
Deploy demo to ng-5 (gateway)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -204,6 +204,7 @@ prod-deploy-otel-ingest-agent-eks:
     # - aws sts get-caller-identity
     - bash $SCRIPT
 
+# Demo env:otel-staging
 staging-deploy-otel-demo-eks:
   !!merge <<: *staging-deploy
   variables:
@@ -214,6 +215,7 @@ staging-deploy-otel-demo-eks:
     CLUSTER_NAME: dd-otel
     CLUSTER_ARN: "arn:aws:eks:us-east-1:601427279990:cluster/dd-otel"
     REGION: us-east-1
+# Demo env:otel-ingest-staging
 staging-deploy-otel-ingest-demo-eks:
   !!merge <<: *staging-deploy
   variables:
@@ -224,6 +226,7 @@ staging-deploy-otel-ingest-demo-eks:
     CLUSTER_NAME: dd-otel
     CLUSTER_ARN: "arn:aws:eks:us-east-1:601427279990:cluster/dd-otel"
     REGION: us-east-1
+# Agent env:otel-ingest-staging
 staging-deploy-otel-ingest-agent-eks:
   !!merge <<: *staging-deploy
   variables:
@@ -233,3 +236,14 @@ staging-deploy-otel-ingest-agent-eks:
     CLUSTER_ARN: "arn:aws:eks:us-east-1:601427279990:cluster/dd-otel"
     REGION: us-east-1
     VALUES: ./ci/datadog-agent-values-staging.yaml
+# Demo env:otel-gateway
+staging-deploy-gateway-demo-eks:
+  !!merge <<: *staging-deploy
+  variables:
+    NAMESPACE: otel-gateway
+    VALUES: ./ci/values-gateway.yaml
+    NODE_GROUP: ng-5
+    SCRIPT: ./ci/scripts/ci-deploy-demo-staging.sh
+    CLUSTER_NAME: dd-otel
+    CLUSTER_ARN: "arn:aws:eks:us-east-1:601427279990:cluster/dd-otel"
+    REGION: us-east-1

--- a/ci/values-gateway.yaml
+++ b/ci/values-gateway.yaml
@@ -1,0 +1,9 @@
+default:
+  envOverrides:
+    - name: OTEL_COLLECTOR_NAME
+      value: opentelemetry-collector
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://opentelemetry-collector:4317
+  schedulingRules:
+    nodeSelector:
+      alpha.eksctl.io/nodegroup-name: ng-5


### PR DESCRIPTION
This PR deploys the demo to the gateway namespace (ng-5). It does not add `datadog.host.name` as mentioned in the [doc](https://docs.google.com/document/d/1E1j2vIl1KWvDfyb34ulPRu8pSPGoeMHYQiR99A3IS-8/edit#heading=h.h5emedcprbz), as `k8s.pod.ip` is already being added, so the k8sattributes processor is able to extract the hostname using this. 