### PR TITLE
Deploy demo to ng-6 (Daemonset => Gateway)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -247,3 +247,14 @@ staging-deploy-gateway-demo-eks:
     CLUSTER_NAME: dd-otel
     CLUSTER_ARN: "arn:aws:eks:us-east-1:601427279990:cluster/dd-otel"
     REGION: us-east-1
+# Demo env:otel-ds-gateway
+staging-deploy-ds-gateway-demo-eks:
+  !!merge <<: *staging-deploy
+  variables:
+    NAMESPACE: otel-ds-gateway
+    VALUES: ./ci/values-ds-gateway.yaml
+    NODE_GROUP: ng-6
+    SCRIPT: ./ci/scripts/ci-deploy-demo-staging.sh
+    CLUSTER_NAME: dd-otel
+    CLUSTER_ARN: "arn:aws:eks:us-east-1:601427279990:cluster/dd-otel"
+    REGION: us-east-1

--- a/ci/values-ds-gateway.yaml
+++ b/ci/values-ds-gateway.yaml
@@ -1,0 +1,4 @@
+default:
+  schedulingRules:
+    nodeSelector:
+      alpha.eksctl.io/nodegroup-name: ng-6

--- a/src/productcatalogservice/main.go
+++ b/src/productcatalogservice/main.go
@@ -20,7 +20,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/contrib/instrumentation/runtime"
-	"go.opentelemetry.io/otel/sdk/instrumentation"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
@@ -99,32 +98,9 @@ func initMeterProvider() *sdkmetric.MeterProvider {
 	mp := sdkmetric.NewMeterProvider(
 		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter)),
 		sdkmetric.WithResource(initResource()),
-		sdkmetric.WithView(			
-			sdkmetric.NewView(
-				sdkmetric.Instrument{Scope: instrumentation.Scope{Name: "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"}},
-				sdkmetric.Stream{
-					AttributeFilter: allowedAttr(
-						"http.method",
-						"http.status_code",
-						"http.target",
-					),
-				},
-			),
-		),
 	)
 	otel.SetMeterProvider(mp)
 	return mp
-}
-
-func allowedAttr(v ...string) attribute.Filter {
-	m := make(map[string]struct{}, len(v))
-	for _, s := range v {
-		m[s] = struct{}{}
-	}
-	return func(kv attribute.KeyValue) bool {
-		_, ok := m[string(kv.Key)]
-		return ok
-	}
 }
 
 func main() {

--- a/src/productcatalogservice/main.go
+++ b/src/productcatalogservice/main.go
@@ -103,10 +103,9 @@ func initMeterProvider() *sdkmetric.MeterProvider {
 			sdkmetric.NewView(
 				sdkmetric.Instrument{Scope: instrumentation.Scope{Name: "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"}},
 				sdkmetric.Stream{
-					AttributeFilter: allowedAttr(
-						"http.method",
-						"http.status_code",
-						"http.target",
+					AttributeFilter: disallowedAttr(
+						"net.sock.peer.port",
+						"net.sock.peer.addr",
 					),
 				},
 			),
@@ -116,14 +115,14 @@ func initMeterProvider() *sdkmetric.MeterProvider {
 	return mp
 }
 
-func allowedAttr(v ...string) attribute.Filter {
+func disallowedAttr(v ...string) attribute.Filter {
 	m := make(map[string]struct{}, len(v))
 	for _, s := range v {
 		m[s] = struct{}{}
 	}
 	return func(kv attribute.KeyValue) bool {
 		_, ok := m[string(kv.Key)]
-		return ok
+		return !ok
 	}
 }
 

--- a/src/productcatalogservice/main.go
+++ b/src/productcatalogservice/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/contrib/instrumentation/runtime"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
@@ -98,9 +99,32 @@ func initMeterProvider() *sdkmetric.MeterProvider {
 	mp := sdkmetric.NewMeterProvider(
 		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter)),
 		sdkmetric.WithResource(initResource()),
+		sdkmetric.WithView(			
+			sdkmetric.NewView(
+				sdkmetric.Instrument{Scope: instrumentation.Scope{Name: "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"}},
+				sdkmetric.Stream{
+					AttributeFilter: allowedAttr(
+						"http.method",
+						"http.status_code",
+						"http.target",
+					),
+				},
+			),
+		),
 	)
 	otel.SetMeterProvider(mp)
 	return mp
+}
+
+func allowedAttr(v ...string) attribute.Filter {
+	m := make(map[string]struct{}, len(v))
+	for _, s := range v {
+		m[s] = struct{}{}
+	}
+	return func(kv attribute.KeyValue) bool {
+		_, ok := m[string(kv.Key)]
+		return ok
+	}
 }
 
 func main() {


### PR DESCRIPTION
Collector PR: DataDog/opentelemetry-collector-contrib#4376

This PR deploys demo to `ng-6`. 

It also performs a fix to product catalog service which was causing high memory consumption. 
See https://app.datadoghq.com/notebook/6461691/investigating-collector-oom-in-env-otel-gateway for investigation of issue. 