### PR TITLE
Add annotations for kafka_consumer integration

### DIFF
--- a/ci/values.yaml
+++ b/ci/values.yaml
@@ -197,10 +197,6 @@ components:
             ]
           },
           "kafka_consumer": {
-            "init_config": {
-              "is_jmx": true,
-              "collect_default_metrics": true
-            },
             "instances": [
               {
                 "kafka_connect_str": "opentelemetry-demo-kafka:9092",

--- a/ci/values.yaml
+++ b/ci/values.yaml
@@ -195,10 +195,7 @@ components:
                 ]
               }
             ]
-          }
-        }
-      ad.datadoghq.com/kafka_consumer.checks: |
-        {
+          },
           "kafka_consumer": {
             "init_config": {
               "is_jmx": true,

--- a/ci/values.yaml
+++ b/ci/values.yaml
@@ -197,6 +197,23 @@ components:
             ]
           }
         }
+      ad.datadoghq.com/kafka_consumer.checks: |
+        {
+          "kafka_consumer": {
+            "init_config": {
+              "is_jmx": true,
+              "collect_default_metrics": true
+            },
+            "instances": [
+              {
+                "kafka_connect_str": "opentelemetry-demo-kafka:9092",
+                "tags": [
+                  "kafka_source:agent"
+                ]
+              }
+            ]
+          }
+        }
 serviceAccount:
   create: false
 opentelemetry-collector:

--- a/ci/values.yaml
+++ b/ci/values.yaml
@@ -200,6 +200,7 @@ components:
             "instances": [
               {
                 "kafka_connect_str": "opentelemetry-demo-kafka:9092",
+                "monitor_unlisted_consumer_groups": true,
                 "tags": [
                   "kafka_source:agent"
                 ]


### PR DESCRIPTION
This PR adds the annotations in order for the agent to pick up the kafka consumer integration. Metrics can be found here: https://app.datadoghq.com/metric/summary?filter=kafka.consumer_offset&tags=env%3Aotel-ingest-staging%2Ckafka_source%3Aagent in OTel org.