### PR TITLE
Add custom container tag

### DIFF
--- a/ci/datadog-agent-values.yaml
+++ b/ci/datadog-agent-values.yaml
@@ -1,5 +1,6 @@
 agents:
   image:
+    tag: 7.50.0-rc.1
     tagSuffix: jmx
 datadog:
   apiKey: $DD_API_KEY

--- a/kubernetes/opentelemetry-demo.yaml
+++ b/kubernetes/opentelemetry-demo.yaml
@@ -8367,7 +8367,7 @@ spec:
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
-            value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
+            value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME),datadog.container.tag.team=otel
           resources:
             limits:
               memory: 500Mi

--- a/src/orderproducerservice/deployment-staging.yaml
+++ b/src/orderproducerservice/deployment-staging.yaml
@@ -119,7 +119,8 @@ spec:
               k8s.node.name=$(OTEL_K8S_NODE_NAME),
               k8s.pod.name=$(OTEL_K8S_POD_NAME),
               deployment.environment=$(OTEL_K8S_NAMESPACE),
-              k8s.pod.ip=$(POD_IP)
+              k8s.pod.ip=$(POD_IP),
+              datadog.container.tag.team=otel
           resources:
             limits:
               memory: 1Gi

--- a/src/productcatalogservice/main.go
+++ b/src/productcatalogservice/main.go
@@ -63,6 +63,7 @@ func initResource() *sdkresource.Resource {
 			sdkresource.WithProcess(),
 			sdkresource.WithContainer(),
 			sdkresource.WithHost(),
+			sdkresource.WithAttributes(attribute.String("datadog.container.tag.team", "otel")),
 		)
 		resource, _ = sdkresource.Merge(
 			sdkresource.Default(),

--- a/src/recommendationservice/recommendation_server.py
+++ b/src/recommendationservice/recommendation_server.py
@@ -135,6 +135,7 @@ if __name__ == "__main__":
         resource=Resource.create(
             {
                 'service.name': service_name,
+               'datadog.container.tag.team': "otel",
             }
         ),
     )


### PR DESCRIPTION
# Changes

This PR adds custom container tagging for:

**env:otel-staging**
- orderproducerservice ([traces](https://app.datadoghq.com/apm/traces?query=%40_top_level%3A1%20env%3Aotel-staging%20service%3Aorderproducer%20team%3Aotel&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&graphType=flamegraph&historicalData=false&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=time&spanID=10413683428080567682&spanType=service-entry&spanViewType=infrastructure&timeHint=1699884024405&trace=afa839f12971c09b9852a743ef76f6bf10413683428080567682&traceID=afa839f12971c09b9852a743ef76f6bf&traceQuery=&view=spans&start=1699883117660&end=1699884017660&paused=false))
- productcatalogservice ([metrics](https://app.datadoghq.com/metric/summary?metric=rpc.server.duration.count&tags=service%3Aproductcatalogservice%2Cenv%3Aotel-staging%2Cteam%3Aotel))
- recommendationservice ([logs](https://app.datadoghq.com/logs?query=env%3Aotel-staging%20team%3Aotel%20&agg_q=kube_container_name&cols=host%2Cservice&index=%2A&messageDisplay=inline&refresh_mode=sliding&sort_m=&sort_t=&stream_sort=desc&top_n=10&top_o=top&view=spans&viz=stream&x_missing=true&from_ts=1699881627577&to_ts=1699882527577&live=true))

**env:otel-ingest-staging**
- orderproducerservice ([traces](https://app.datadoghq.com/apm/traces?query=%40_top_level%3A1%20env%3Aotel-ingest-staging%20service%3Aorderproducer%20team%3Aotel&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&graphType=flamegraph&historicalData=true&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=time&spanID=3152897444720059671&spanType=service-entry&spanViewType=infrastructure&timeHint=1699887422045&tq_query_translation_version=v0&trace=AgAAAYvJL5pdBeBAuAAAAAAAAAAYAAAAAEFZdkpMN1JtQUFBa2RYSzgzZm44dDI4SgAAACQAAAAAMDE4YmM5MzAtYWIyNS00Mzk1LWE5YTgtYzdkZDM2M2M1ZWZk&traceID=1c6e08b28063ce3c096f3e2323915322&traceQuery=&view=spans&start=1699886653691&end=1699887553691&paused=false))
- productcatalogservice ([metrics](https://app.datadoghq.com/metric/summary?metric=rpc.server.duration&tags=service%3Aproductcatalogservice%2Cenv%3Aotel-ingest-staging%2Cteam%3Aotel))
