### PR TITLE
[OTEL-1363] Fix loadgenerator

### DIFF
--- a/src/loadgenerator/locustfile.py
+++ b/src/loadgenerator/locustfile.py
@@ -10,18 +10,29 @@ import uuid
 from locust import HttpUser, task, between
 
 from opentelemetry import context, baggage, trace
+from opentelemetry.metrics import set_meter_provider
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import MetricExporter, PeriodicExportingMetricReader
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.jinja2 import Jinja2Instrumentor
 from opentelemetry.instrumentation.requests import RequestsInstrumentor
+from opentelemetry.instrumentation.system_metrics import SystemMetricsInstrumentor
 from opentelemetry.instrumentation.urllib3 import URLLib3Instrumentor
+
+exporter = OTLPMetricExporter(insecure=True)
+set_meter_provider(MeterProvider([PeriodicExportingMetricReader(exporter)]))
 
 tracer_provider = TracerProvider()
 trace.set_tracer_provider(tracer_provider)
 tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
 
 # Instrumenting manually to avoid error with locust gevent monkey
+Jinja2Instrumentor().instrument()
 RequestsInstrumentor().instrument()
+SystemMetricsInstrumentor().instrument()
 URLLib3Instrumentor().instrument()
 
 categories = [


### PR DESCRIPTION
All changes are from upstream.

`loadgenerator` has been broken for several months:
![Screenshot 2024-01-08 at 4 01 50 PM](https://github.com/DataDog/opentelemetry-demo/assets/10536136/ffbfa097-bb50-4fe2-a294-16880050d3b5)

Now services are fixed:
![Screenshot 2024-01-08 at 4 03 09 PM](https://github.com/DataDog/opentelemetry-demo/assets/10536136/09f44823-fd61-487a-9529-1a957944508d)
