### PR TITLE
[OTEL-1365] Set up CIs for dd-ingest-staging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -226,6 +226,17 @@ staging-deploy-otel-ingest-demo-eks:
     CLUSTER_NAME: dd-otel
     CLUSTER_ARN: "arn:aws:eks:us-east-1:601427279990:cluster/dd-otel"
     REGION: us-east-1
+# Demo env:dd-ingest-staging
+staging-deploy-dd-ingest-demo-eks:
+  !!merge <<: *staging-deploy
+  variables:
+    NAMESPACE: dd-ingest-staging
+    VALUES: ./ci/values-dd-ingest-staging.yaml
+    NODE_GROUP: ng-7
+    SCRIPT: ./ci/scripts/ci-deploy-demo-staging.sh
+    CLUSTER_NAME: dd-otel
+    CLUSTER_ARN: "arn:aws:eks:us-east-1:601427279990:cluster/dd-otel"
+    REGION: us-east-1
 # Agent env:otel-ingest-staging
 staging-deploy-otel-ingest-agent-eks:
   !!merge <<: *staging-deploy
@@ -236,6 +247,20 @@ staging-deploy-otel-ingest-agent-eks:
     CLUSTER_ARN: "arn:aws:eks:us-east-1:601427279990:cluster/dd-otel"
     REGION: us-east-1
     VALUES: ./ci/datadog-agent-values-staging.yaml
+    DD_VALUES: ./ci/datadog-agent-values.yaml
+    RELEASE_NAME: datadog-agent
+# Agent env:dd-ingest-staging
+staging-deploy-dd-ingest-agent-eks:
+  !!merge <<: *staging-deploy
+  variables:
+    NAMESPACE: dd-ingest-staging
+    SCRIPT: ./ci/scripts/ci-deploy-agent.sh
+    CLUSTER_NAME: dd-otel
+    CLUSTER_ARN: "arn:aws:eks:us-east-1:601427279990:cluster/dd-otel"
+    REGION: us-east-1
+    VALUES: ./ci/datadog-agent-values-dd-staging.yaml
+    DD_VALUES: ./ci/datadog-agent-values-dd.yaml
+    RELEASE_NAME: datadog-agent-dd
 # Demo env:otel-gateway
 staging-deploy-gateway-demo-eks:
   !!merge <<: *staging-deploy

--- a/ci/datadog-agent-values-dd-staging.yaml
+++ b/ci/datadog-agent-values-dd-staging.yaml
@@ -1,0 +1,6 @@
+agents:
+  nodeSelector:
+    alpha.eksctl.io/nodegroup-name: ng-7
+datadog:
+  tags:
+    - "env:dd-ingest-staging"

--- a/ci/datadog-agent-values-dd.yaml
+++ b/ci/datadog-agent-values-dd.yaml
@@ -4,15 +4,11 @@ agents:
     tagSuffix: jmx
 datadog:
   apiKey: $DD_API_KEY
+  apm:
+    portEnabled: true
+    port: 8126
   logs:
     enabled: true
-  otlp:
-    receiver:
-      protocols:
-        grpc:
-          enabled: true
-        http:
-          enabled: true
   env:
     - name: DD_API_KEY
       valueFrom:

--- a/ci/scripts/ci-deploy-agent.sh
+++ b/ci/scripts/ci-deploy-agent.sh
@@ -12,18 +12,17 @@ clusterName=$CLUSTER_NAME
 clusterArn=$CLUSTER_ARN
 region=$REGION
 namespace=$NAMESPACE
+releaseName=$RELEASE_NAME
+ddValues=$DD_VALUES
 values=$VALUES
 
 install_agent() {
-  # Set the namespace and release name
-  release_name="datadog-agent"
-
   # if repo already exists, helm 3+ will skip
   helm repo add datadog https://helm.datadoghq.com
 
   # --install will run `helm install` if not already present.
-  helm upgrade "${release_name}" -n "${namespace}" datadog/datadog --install \
-    -f ./ci/datadog-agent-values.yaml \
+  helm upgrade "${releaseName}" -n "${namespace}" datadog/datadog --install \
+    -f "${ddValues}" \
     -f "${values}"
 }
 

--- a/ci/values-dd-ingest-staging.yaml
+++ b/ci/values-dd-ingest-staging.yaml
@@ -1,0 +1,4 @@
+default:
+  schedulingRules:
+    nodeSelector:
+      alpha.eksctl.io/nodegroup-name: ng-7

--- a/ci/values.yaml
+++ b/ci/values.yaml
@@ -35,6 +35,8 @@ default:
       valueFrom:
         fieldRef:
           fieldPath: status.hostIP
+    - name: DD_AGENT_HOST
+      value: $(HOST_IP)
     - name: OTEL_COLLECTOR_NAME
       value: $(HOST_IP)
     - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/src/orderproducerservice/deployment-staging.yaml
+++ b/src/orderproducerservice/deployment-staging.yaml
@@ -50,6 +50,7 @@ spec:
                     operator: In
                     values:
                       - ng-4
+                      - ng-7
       initContainers:
         - command:
           - sh

--- a/src/zookeeperservice/deployment-staging.yaml
+++ b/src/zookeeperservice/deployment-staging.yaml
@@ -46,6 +46,7 @@ spec:
                     operator: In
                     values:
                       - ng-4
+                      - ng-7
       containers:
         - name: zookeeper
           image: confluentinc/cp-zookeeper:7.2.2


### PR DESCRIPTION
Add CI deployment to a new node group and namespace  dd-ingest-staging.
This is similar to https://github.com/DataDog/opentelemetry-demo/commit/113bcbd2e75b4ee23bb4f46b2b40331332a51052.