### PR TITLE
Add converged agent deployment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -298,7 +298,7 @@ staging-deploy-dd-ingest-demo-eks:
     REGISTRY: $BUILD_SANDBOX_REGISTRY
 
 # Demo env:converged-agent-staging
-staging-deploy-dd-ingest-demo-eks:
+staging-deploy-converged-agent-demo-eks:
   !!merge <<: *staging-deploy
   variables:
     NAMESPACE: converged-agent-staging

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -297,6 +297,21 @@ staging-deploy-dd-ingest-demo-eks:
     ORDERPRODUCER_DEPLOYMENT: deployment-staging.yaml
     REGISTRY: $BUILD_SANDBOX_REGISTRY
 
+# Demo env:converged-agent-staging
+staging-deploy-dd-ingest-demo-eks:
+  !!merge <<: *staging-deploy
+  variables:
+    NAMESPACE: converged-agent-staging
+    VALUES: 
+    NODE_GROUP: ng-8
+    SCRIPT: ./ci/scripts/ci-deploy-demo.sh
+    CLUSTER_NAME: dd-otel
+    CLUSTER_ARN: "arn:aws:eks:us-east-1:601427279990:cluster/dd-otel"
+    REGION: us-east-1
+    ZOOKEEPER_DEPLOYMENT: deployment-staging.yaml
+    ORDERPRODUCER_DEPLOYMENT: deployment-staging.yaml
+    REGISTRY: $BUILD_SANDBOX_REGISTRY
+
 # Agent env:otel-ingest-staging
 staging-deploy-otel-ingest-agent-eks:
   !!merge <<: *staging-deploy
@@ -326,7 +341,7 @@ staging-deploy-converged-agent-staging-eks:
   !!merge <<: *staging-deploy
   variables:
     NAMESPACE: converged-agent-staging
-    SCRIPT: ./ci/scripts/ci-deploy-agent.sh
+    SCRIPT: ./ci/scripts/ci-deploy-converged-agent.sh
     CLUSTER_NAME: dd-otel
     CLUSTER_ARN: "arn:aws:eks:us-east-1:601427279990:cluster/dd-otel"
     REGION: us-east-1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -320,3 +320,15 @@ staging-deploy-dd-ingest-agent-eks:
     REGION: us-east-1
     RELEASE_NAME: datadog-agent-dd
     NODE_GROUP: ng-7
+
+# Agent env:converged-agent-staging
+staging-deploy-converged-agent-staging-eks:
+  !!merge <<: *staging-deploy
+  variables:
+    NAMESPACE: converged-agent-staging
+    SCRIPT: ./ci/scripts/ci-deploy-agent.sh
+    CLUSTER_NAME: dd-otel
+    CLUSTER_ARN: "arn:aws:eks:us-east-1:601427279990:cluster/dd-otel"
+    REGION: us-east-1
+    RELEASE_NAME: converged-agent-staging
+    NODE_GROUP: ng-8

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -345,5 +345,5 @@ staging-deploy-converged-agent-staging-eks:
     CLUSTER_NAME: dd-otel
     CLUSTER_ARN: "arn:aws:eks:us-east-1:601427279990:cluster/dd-otel"
     REGION: us-east-1
-    RELEASE_NAME: converged-agent-staging
+    RELEASE_NAME: converged-agent
     NODE_GROUP: ng-8

--- a/ci/converged-agent-values/values.yaml
+++ b/ci/converged-agent-values/values.yaml
@@ -1,6 +1,6 @@
 agents:
   image:
-    tag: 7.55.2
+    tag: 7-ot-beta
     tagSuffix: jmx
 datadog:
   apiKeyExistingSecret: datadog-secrets

--- a/ci/converged-agent-values/values.yaml
+++ b/ci/converged-agent-values/values.yaml
@@ -1,6 +1,6 @@
 agents:
   image:
-    tag: 7.55.0
+    tag: 7.55.2
     tagSuffix: jmx
 datadog:
   apiKeyExistingSecret: datadog-secrets
@@ -134,7 +134,7 @@ datadog:
         logs:
           encoding: "json"
           initial_fields:
-            - service: "otel-collector"
+            - service: "converged-agent"
       pipelines:
         metrics:
           receivers: [otlp, datadog/connector]

--- a/ci/converged-agent-values/values.yaml
+++ b/ci/converged-agent-values/values.yaml
@@ -6,7 +6,15 @@ agents:
 datadog:
   apiKeyExistingSecret: datadog-secrets
   otelCollector:
-    ports: `[{"containerPort":"4317", "hostPort":"4317", "name":"otel-grpc"},{"containerPort":"4318", "hostPort":"4318", "name":"otel-http"}]`
+    ports:
+      - containerPort: 4317
+        hostPort: 4317
+        name: grpcport
+        protocol: UDP
+      - containerPort: 4318
+        hostPort: 4318
+        name: httpport
+        protocol: UDP
     enabled: true
     config: |
     receivers:

--- a/ci/converged-agent-values/values.yaml
+++ b/ci/converged-agent-values/values.yaml
@@ -1,22 +1,12 @@
 registry: docker.io/datadog
 agents:
-  containers: 
-    otelAgent: 
-      ports:
-        - containerPort: 4317
-          hostPort: 4317
-          name: grpcport
-          protocol: UDP
-        - containerPort: 4318
-          hostPort: 4318
-          name: httpport
-          protocol: UDP
   image:
     repository: datadog/agent-dev
     tag: nightly-ot-beta-main-jmx
 datadog:
   apiKeyExistingSecret: datadog-secrets
   otelCollector:
+    ports: `[{"containerPort":"4317", "hostPort":"4317", "name":"otel-grpc"},{"containerPort":"4318", "hostPort":"4318", "name":"otel-http"}]`
     enabled: true
     config: |
     receivers:

--- a/ci/converged-agent-values/values.yaml
+++ b/ci/converged-agent-values/values.yaml
@@ -1,3 +1,4 @@
+registry: docker.io/datadog
 agents:
   image:
     repository: datadog/agent-dev

--- a/ci/converged-agent-values/values.yaml
+++ b/ci/converged-agent-values/values.yaml
@@ -3,8 +3,14 @@ agents:
   containers: 
     otelAgent: 
       ports:
-      - hostPort: 4317
-      - hostPort: 4318
+        - containerPort: 4317
+          hostPort: 4317
+          name: grpcport
+          protocol: UDP
+        - containerPort: 4318
+          hostPort: 4318
+          name: httpport
+          protocol: UDP
   image:
     repository: datadog/agent-dev
     tag: nightly-ot-beta-main-jmx

--- a/ci/converged-agent-values/values.yaml
+++ b/ci/converged-agent-values/values.yaml
@@ -6,15 +6,7 @@ agents:
 datadog:
   apiKeyExistingSecret: datadog-secrets
   otelCollector:
-    ports:
-      - containerPort: 4317
-        hostPort: 4317
-        name: grpcport
-        protocol: UDP
-      - containerPort: 4318
-        hostPort: 4318
-        name: httpport
-        protocol: UDP
+    ports: [{"containerPort":"4317", "hostPort":"4317" ,"name":"otel-grpc"},{"containerPort":"4318", "hostPort":"4318" ,"name":"otel-http"}]
     enabled: true
     config: |
     receivers:

--- a/ci/converged-agent-values/values.yaml
+++ b/ci/converged-agent-values/values.yaml
@@ -1,5 +1,10 @@
 registry: docker.io/datadog
 agents:
+  containers: 
+    otelAgent: 
+      ports:
+        - hostPort: 4317
+        - hostPort: 4318
   image:
     repository: datadog/agent-dev
     tag: nightly-ot-beta-main-jmx

--- a/ci/converged-agent-values/values.yaml
+++ b/ci/converged-agent-values/values.yaml
@@ -1,0 +1,153 @@
+agents:
+  image:
+    tag: 7.55.0
+    tagSuffix: jmx
+datadog:
+  apiKeyExistingSecret: datadog-secrets
+  otelCollector:
+    enabled: true
+    config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+    exporters:
+      debug:
+        verbosity: detailed
+      datadog:
+        host_metadata:
+          tags: ['env:${env:OTEL_K8S_NAMESPACE}']
+        metrics:
+          resource_attributes_as_tags: true
+          histograms:
+            mode: counters
+            send_count_sum_metrics: true
+        traces:
+          span_name_as_resource_name: true
+          compute_stats_by_span_kind: true
+          peer_service_aggregation: true
+          trace_buffer: 1000
+        api:
+          key: "$DD_API_KEY"
+    processors:
+      resourcedetection:
+        # ensures host.name and other important resource tags
+        # get picked up
+        detectors: [env, gcp, ecs, ec2, azure, system]
+        timeout: 5s
+        override: false
+        system:
+          # Enable optional system attributes
+          resource_attributes:
+            os.type:
+              enabled: true
+            os.description:
+              enabled: true
+            host.ip:
+              enabled: true
+            host.mac:
+              enabled: true
+            host.arch:
+              enabled: true
+            host.cpu.vendor.id:
+              enabled: true
+            host.cpu.model.name:
+              enabled: true
+            host.cpu.family:
+              enabled: true
+            host.cpu.model.id:
+              enabled: true
+            host.cpu.stepping:
+              enabled: true
+            host.cpu.cache.l2.size:
+              enabled: true
+            host.id:
+              enabled: false
+      # adds various tags related to k8s
+      # adds various tags related to k8s
+      k8sattributes:
+        passthrough: false
+        auth_type: "serviceAccount"
+        pod_association:
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.ip
+        extract:
+          metadata:
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.deployment.name
+            - k8s.node.name
+            - k8s.namespace.name
+            - k8s.pod.start_time
+            - k8s.replicaset.name
+            - k8s.replicaset.uid
+            - k8s.daemonset.name
+            - k8s.daemonset.uid
+            - k8s.job.name
+            - k8s.job.uid
+            - k8s.cronjob.name
+            - k8s.statefulset.name
+            - k8s.statefulset.uid
+            - container.image.name
+            - container.image.tag
+            - container.id
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+            - container.id
+          labels:
+            - tag_name: kube_app_name
+              key: app.kubernetes.io/name
+              from: pod
+            - tag_name: kube_app_instance
+              key: app.kubernetes.io/instance
+              from: pod
+            - tag_name: kube_app_version
+              key: app.kubernetes.io/version
+              from: pod
+            - tag_name: kube_app_component
+              key: app.kubernetes.io/component
+              from: pod
+            - tag_name: kube_app_part_of
+              key: app.kubernetes.io/part-of
+              from: pod
+            - tag_name: kube_app_managed_by
+              key: app.kubernetes.io/managed-by
+              from: pod
+      batch:
+        send_batch_max_size: 1000
+        send_batch_size: 100
+        timeout: 10s
+      probabilistic_sampler:
+        hash_seed: 22
+        sampling_percentage: 15.3
+    connectors:
+      datadog/connector:
+        traces:
+          span_name_as_resource_name: true
+    service:
+      telemetry:
+        logs:
+          encoding: "json"
+          initial_fields:
+            - service: "otel-collector"
+      pipelines:
+        metrics:
+          receivers: [otlp, datadog/connector]
+          processors: [resourcedetection, k8sattributes, batch]
+          exporters: [datadog]
+        traces:
+          receivers: [otlp]
+          processors: [resourcedetection, k8sattributes, batch]
+          exporters: [datadog/connector]
+        traces/sampled:
+          receivers: [datadog/connector]
+          processors: [probabilistic_sampler, batch]
+          exporters: [datadog]
+        logs:
+          processors: [resourcedetection, k8sattributes, batch]
+          exporters: [datadog]

--- a/ci/converged-agent-values/values.yaml
+++ b/ci/converged-agent-values/values.yaml
@@ -3,7 +3,6 @@ agents:
   image:
     repository: datadog/agent-dev
     tag: nightly-ot-beta-main-jmx
-    tagSuffix: jmx
 datadog:
   apiKeyExistingSecret: datadog-secrets
   otelCollector:

--- a/ci/converged-agent-values/values.yaml
+++ b/ci/converged-agent-values/values.yaml
@@ -1,5 +1,6 @@
 agents:
   image:
+    repository: datadog/agent-dev
     tag: nightly-ot-beta-main-jmx
     tagSuffix: jmx
 datadog:

--- a/ci/converged-agent-values/values.yaml
+++ b/ci/converged-agent-values/values.yaml
@@ -143,7 +143,7 @@ datadog:
         traces:
           receivers: [otlp]
           processors: [resourcedetection, k8sattributes, batch]
-          exporters: [datadog/connector]
+          exporters: [datadog/connector, debug]
         traces/sampled:
           receivers: [datadog/connector]
           processors: [probabilistic_sampler, batch]

--- a/ci/converged-agent-values/values.yaml
+++ b/ci/converged-agent-values/values.yaml
@@ -3,8 +3,8 @@ agents:
   containers: 
     otelAgent: 
       ports:
-        - hostPort: 4317
-        - hostPort: 4318
+      - hostPort: 4317
+      - hostPort: 4318
   image:
     repository: datadog/agent-dev
     tag: nightly-ot-beta-main-jmx

--- a/ci/converged-agent-values/values.yaml
+++ b/ci/converged-agent-values/values.yaml
@@ -1,6 +1,6 @@
 agents:
   image:
-    tag: 7-ot-beta
+    tag: nightly-ot-beta-main-jmx
     tagSuffix: jmx
 datadog:
   apiKeyExistingSecret: datadog-secrets

--- a/ci/scripts/ci-deploy-converged-agent.sh
+++ b/ci/scripts/ci-deploy-converged-agent.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# This script is used to deploy collector on demo account cluster
+
+set -euo pipefail
+IFS=$'\n\t'
+
+clusterName=$CLUSTER_NAME
+clusterArn=$CLUSTER_ARN
+region=$REGION
+namespace=$NAMESPACE
+releaseName=$RELEASE_NAME
+nodegroup=$NODE_GROUP
+
+install_agent() {
+  # if repo already exists, helm 3+ will skip
+  helm repo add datadog https://helm.datadoghq.com
+
+  # --install will run `helm install` if not already present.
+  helm_cmd="helm --debug upgrade "${releaseName}" -n "${namespace}" datadog/datadog --install \
+    -f ./ci/converged-agent-values/values.yaml \
+    --set datadog.tags=env:"${namespace}" \
+    --set agents.nodeSelector.\"alpha\\.eksctl\\.io/nodegroup-name\"=${nodegroup}"
+
+  eval $helm_cmd
+}
+
+###########################################################################################################
+
+aws eks --region "${region}" update-kubeconfig --name "${clusterName}"
+kubectl config use-context "${clusterArn}"
+
+install_agent

--- a/ci/scripts/ci-deploy-converged-agent.sh
+++ b/ci/scripts/ci-deploy-converged-agent.sh
@@ -23,7 +23,8 @@ install_agent() {
   helm_cmd="helm --debug upgrade "${releaseName}" -n "${namespace}" datadog/datadog --install \
     -f ./ci/converged-agent-values/values.yaml \
     --set datadog.tags=env:"${namespace}" \
-    --set agents.nodeSelector.\"alpha\\.eksctl\\.io/nodegroup-name\"=${nodegroup}"
+    --set agents.nodeSelector.\"alpha\\.eksctl\\.io/nodegroup-name\"=${nodegroup} \
+    --set agents.image.doNotCheckTag=true"
 
   eval $helm_cmd
 }

--- a/ci/scripts/ci-deploy-demo.sh
+++ b/ci/scripts/ci-deploy-demo.sh
@@ -22,7 +22,7 @@ registry=$REGISTRY
 install_demo() {
   release_name="opentelemetry-demo"
 
-  # helm uninstall ${release_name} -n ${namespace}
+  helm uninstall ${release_name} -n ${namespace}
   
   # HELM COMMAND
   helm_cmd="helm --debug upgrade ${release_name} -n ${namespace} open-telemetry/opentelemetry-demo --install \

--- a/ci/scripts/ci-deploy-demo.sh
+++ b/ci/scripts/ci-deploy-demo.sh
@@ -22,7 +22,7 @@ registry=$REGISTRY
 install_demo() {
   release_name="opentelemetry-demo"
 
-  helm uninstall ${release_name} -n ${namespace}
+  # helm uninstall ${release_name} -n ${namespace}
   
   # HELM COMMAND
   helm_cmd="helm --debug upgrade ${release_name} -n ${namespace} open-telemetry/opentelemetry-demo --install \


### PR DESCRIPTION
# Changes

Deploys converged agent to nodegroup `ng-8` namespace `converged-agent-staging`. See data coming in:
- https://app.datadoghq.com/notebook/8831171/otel-staging-cluster
- https://app.datadoghq.com/apm/traces?query=env%3Aconverged-agent-staging&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&fromUser=false&historicalData=false&messageDisplay=inline&sort=desc&spanType=all&view=spans&start=1722855482819&end=1722856382819&paused=false
## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
